### PR TITLE
Feature/Core

### DIFF
--- a/src/@components/Core/Base/index.tsx
+++ b/src/@components/Core/Base/index.tsx
@@ -15,6 +15,7 @@ export type BaseProps = PropsWithChildren<{
   borderRadius?: number;
   boxShadow?: Property.BoxShadow;
   backgroundColor?: Color;
+  onClick: React.MouseEventHandler<HTMLDivElement> & ((e: Event) => void);
 }>;
 
 const Base = (props: BaseProps) => {

--- a/src/@components/Core/FlexItem/index.stories.tsx
+++ b/src/@components/Core/FlexItem/index.stories.tsx
@@ -1,8 +1,29 @@
 import React from "react";
+import { FlexBox } from "../Flexbox";
 import FlexItem from "./index";
+import Text from "../Text";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
 export default {
   title: "Core/FlexItem",
   component: FlexItem,
 } as ComponentMeta<typeof FlexItem>;
+
+export const WithinFlexBox: ComponentStory<typeof FlexItem> = () => {
+  return (
+    <FlexBox>
+      <FlexItem>
+        <Text variant="f5-regular">Item1</Text>
+      </FlexItem>
+      <FlexItem flex={1}>
+        <Text variant="f5-regular">Item1</Text>
+      </FlexItem>
+      <FlexItem flex={2}>
+        <Text variant="f5-regular">Item1</Text>
+      </FlexItem>
+      <FlexItem flex={3}>
+        <Text variant="f5-regular">Item1</Text>
+      </FlexItem>
+    </FlexBox>
+  );
+};

--- a/src/@components/Core/FlexItem/index.stories.tsx
+++ b/src/@components/Core/FlexItem/index.stories.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import FlexItem from "./index";
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+
+export default {
+  title: "Core/FlexItem",
+  component: FlexItem,
+} as ComponentMeta<typeof FlexItem>;

--- a/src/@components/Core/FlexItem/index.styles.ts
+++ b/src/@components/Core/FlexItem/index.styles.ts
@@ -1,0 +1,1 @@
+import styled from "styled-components";

--- a/src/@components/Core/FlexItem/index.styles.ts
+++ b/src/@components/Core/FlexItem/index.styles.ts
@@ -1,1 +1,9 @@
 import styled from "styled-components";
+import { Props } from "./index";
+
+export const Container = styled.div<Props>(props => ({
+  flex: props.flex,
+  flexGrow: props.flexGrow,
+  flexShrink: props.flexShrink,
+  flexBasis: props.flexShrink,
+}));

--- a/src/@components/Core/FlexItem/index.tsx
+++ b/src/@components/Core/FlexItem/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const FlexItem = () => {
+  return <div></div>;
+};
+
+export default FlexItem;

--- a/src/@components/Core/FlexItem/index.tsx
+++ b/src/@components/Core/FlexItem/index.tsx
@@ -1,7 +1,18 @@
 import React from "react";
+import { BaseProps } from "../Base/index";
+import { Property } from "csstype";
 
-const FlexItem = () => {
-  return <div></div>;
+import * as Styled from "./index.styles";
+
+export interface Props extends BaseProps {
+  flex?: Property.Flex;
+  flexShrink?: Property.FlexShrink;
+  flexGrow?: Property.FlexGrow;
+  flexBasis?: Property.FlexBasis;
+}
+
+const FlexItem = (props: Props) => {
+  return <Styled.Container {...props} />;
 };
 
 export default FlexItem;

--- a/src/@components/Core/FloatingActionButton/index.stories.tsx
+++ b/src/@components/Core/FloatingActionButton/index.stories.tsx
@@ -2,18 +2,24 @@ import React from "react";
 import FloatingActionButton from "./index";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
+import { ReactComponent as WriteIcon } from "@/assets/icons/icon-write.svg";
+import { ReactComponent as UpIcon } from "@/assets/icons/icon-up.svg";
+
 export default {
   title: "Core/FloatingActionButton",
   component: FloatingActionButton,
-  args: {
-    top: "100%",
-    left: "100%",
-  },
 } as ComponentMeta<typeof FloatingActionButton>;
 
 export const Small: ComponentStory<typeof FloatingActionButton> = args => (
   <FloatingActionButton {...args} variant="small" />
 );
+Small.args = {
+  element: UpIcon,
+};
+
 export const Medium: ComponentStory<typeof FloatingActionButton> = args => (
   <FloatingActionButton {...args} variant="medium" />
 );
+Medium.args = {
+  element: WriteIcon,
+};

--- a/src/@components/Core/FloatingActionButton/index.stories.tsx
+++ b/src/@components/Core/FloatingActionButton/index.stories.tsx
@@ -5,17 +5,30 @@ import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { ReactComponent as WriteIcon } from "@/assets/icons/icon-write.svg";
 import { ReactComponent as UpIcon } from "@/assets/icons/icon-up.svg";
 
+const IconMap = {
+  writeIcon: WriteIcon,
+  upIcon: UpIcon,
+};
+
 export default {
   title: "Core/FloatingActionButton",
   component: FloatingActionButton,
+  argTypes: {
+    element: {
+      control: "select",
+      options: Object.keys(IconMap),
+      mapping: IconMap,
+    },
+  },
 } as ComponentMeta<typeof FloatingActionButton>;
+
+export const Default: ComponentStory<typeof FloatingActionButton> = args => (
+  <FloatingActionButton {...args} />
+);
 
 export const Small: ComponentStory<typeof FloatingActionButton> = args => (
   <FloatingActionButton {...args} variant="small" />
 );
-Small.args = {
-  element: UpIcon,
-};
 
 export const Medium: ComponentStory<typeof FloatingActionButton> = args => (
   <FloatingActionButton {...args} variant="medium" />

--- a/src/@components/Core/FloatingActionButton/index.stories.tsx
+++ b/src/@components/Core/FloatingActionButton/index.stories.tsx
@@ -11,9 +11,9 @@ export default {
   },
 } as ComponentMeta<typeof FloatingActionButton>;
 
-export const Write: ComponentStory<typeof FloatingActionButton> = args => (
-  <FloatingActionButton {...args} variant="write" />
+export const Small: ComponentStory<typeof FloatingActionButton> = args => (
+  <FloatingActionButton {...args} variant="small" />
 );
-export const Up: ComponentStory<typeof FloatingActionButton> = args => (
-  <FloatingActionButton {...args} variant="up" />
+export const Medium: ComponentStory<typeof FloatingActionButton> = args => (
+  <FloatingActionButton {...args} variant="medium" />
 );

--- a/src/@components/Core/FloatingActionButton/index.tsx
+++ b/src/@components/Core/FloatingActionButton/index.tsx
@@ -7,12 +7,12 @@ export type FabVariant = "small" | "medium";
 export interface Props {
   variant: FabVariant;
   zIndex: Property.ZIndex;
-  element: React.FC<React.SVGProps<SVGSVGElement>>;
+  element?: React.FC<React.SVGProps<SVGSVGElement>>;
   onClick?: () => void;
 }
 
 const FloatingActionButton = ({ element, ...props }: Props) => {
-  const Element = element;
+  const Element = element || "div";
 
   return <Styled.Container {...props}>{<Element />}</Styled.Container>;
 };

--- a/src/@components/Core/Input/index.stories.tsx
+++ b/src/@components/Core/Input/index.stories.tsx
@@ -8,7 +8,7 @@ import { LOCATION, SEARCH } from "@/constants/icons";
 const icons = { Empty: null, LOCATION, SEARCH };
 
 export default {
-  title: "Atoms/Input",
+  title: "Core/Input",
   component: Input,
   argTypes: {
     shape: {

--- a/src/@components/Core/Input/index.stories.tsx
+++ b/src/@components/Core/Input/index.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import Input from "./index";
 
-import { LOCATION, SEARCH } from "../../../constants/icons";
+import { LOCATION, SEARCH } from "@/constants/icons";
 
 const icons = { Empty: null, LOCATION, SEARCH };
 

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -24,3 +24,5 @@ export { default as SELECTED_HOME } from "@/assets/icons/icon-selected-home.svg"
 export { default as SELECTED_INFORMATION } from "@/assets/icons/icon-selected-information.svg";
 export { default as SELECTED_LOCATION } from "@/assets/icons/icon-selected-location.svg";
 export { default as SELECTED_PROFILE } from "@/assets/icons/icon-selected-profile.svg";
+export { default as UP } from "@/assets/icons/icon-up.svg";
+export { default as WRITE } from "@/assets/icons/icon-write.svg";


### PR DESCRIPTION
#82 번 이슈에 대응하여 Base의 기능을 업데이트 하였습니다.

- onClick을 사용할 수 있도록 대응
- 부수효과로 Base의 Props를 확장하는 다른 컴포넌트 (FlexBox 등)에서도 사용가능합니다.

#87 번 이슈에 대응하여 오류를 수정하였습니다.
- Input의 스토리의 title을 변경 

#88 번 이슈에 대응하여 Fab의 오류를 수정하고 스토리를 확장했습니다.
- Fab의 엘리먼트가 전달되지 않을 때의 처리를 제대로 안해줘서 발생한 오류를 해결
- 스토리를 보다 사용하기 편하게 옵션 값을 설정
- Default 스토리를 생성 

#94 번 이슈에 대응하여 `FlexItem` 컴포넌트 구현